### PR TITLE
Add new fields to commits.json and flag

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -56,7 +56,7 @@ public class RepoSense {
                 return;
             }
 
-            //basics learning
+            // Json pretty printing
             FileUtil.setPrettyPrintingMode(cliArguments.isPrettyPrintingUsed());
 
             configs = RunConfigurationDecider.getRunConfiguration(cliArguments).getRepoConfigurations();

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -56,6 +56,9 @@ public class RepoSense {
                 return;
             }
 
+            //basics learning
+            FileUtil.setPrettyPrintingMode(cliArguments.isPrettyPrintingUsed());
+
             configs = RunConfigurationDecider.getRunConfiguration(cliArguments).getRepoConfigurations();
             reportConfig = cliArguments.getReportConfiguration();
             repoBlurbMap = cliArguments.mergeWithReportConfigRepoBlurbMap();

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -71,11 +71,12 @@ public class CommitInfoAnalyzer {
      * Analyzes each {@link CommitInfo} in {@code commitInfos} and returns a list of {@link CommitResult} that is not
      * specified to be ignored or the author is inside {@code config}.
      */
-    public List<CommitResult> analyzeCommits(List<CommitInfo> commitInfos, RepoConfiguration config) {
+    public List<CommitResult> analyzeCommits(List<CommitInfo> commitInfos, RepoConfiguration config,
+            boolean shouldIncludeCommitFileStats) {
         logger.info(String.format(MESSAGE_START_ANALYZING_COMMIT_INFO, config.getLocation(), config.getBranch()));
 
         return commitInfos.stream()
-                .map(commitInfo -> analyzeCommit(commitInfo, config))
+                .map(commitInfo -> analyzeCommit(commitInfo, config, shouldIncludeCommitFileStats))
                 .filter(commitResult -> !commitResult.getAuthor().equals(Author.UNKNOWN_AUTHOR)
                         && !CommitHash.isInsideCommitList(commitResult.getHash(), config.getIgnoreCommitList()))
                 .distinct()
@@ -87,7 +88,8 @@ public class CommitInfoAnalyzer {
      * Extracts the relevant data from {@code commitInfo} into a {@link CommitResult}. Retrieves the author of the
      * commit from {@code config}.
      */
-    public CommitResult analyzeCommit(CommitInfo commitInfo, RepoConfiguration config) {
+    public CommitResult analyzeCommit(CommitInfo commitInfo, RepoConfiguration config,
+            boolean shouldIncludeCommitFileStats) {
         String infoLine = commitInfo.getInfoLine();
         String statLine = commitInfo.getStatLine();
 
@@ -120,7 +122,8 @@ public class CommitInfoAnalyzer {
             extractTagNames(tags);
         }
 
-        if (statLine.isEmpty()) { // empty commit, no files changed
+        // empty commit, no files changed || no need to include file stats
+        if (statLine.isEmpty() || !shouldIncludeCommitFileStats) {
             return new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags);
         }
 

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import reposense.commits.model.CommitInfo;
 import reposense.commits.model.CommitResult;
 import reposense.commits.model.ContributionPair;
+import reposense.commits.model.FileChangeStats;
 import reposense.model.Author;
 import reposense.model.CommitHash;
 import reposense.model.FileType;
@@ -57,6 +58,12 @@ public class CommitInfoAnalyzer {
     private static final int MESSAGE_TITLE_INDEX = 5;
     private static final int MESSAGE_BODY_INDEX = 6;
     private static final int REF_NAME_INDEX = 7;
+
+    private static final String INTEGER_REGEX = "-?\\d+";
+    private static final int NUM_FILES_CHANGED_INDEX = 0;
+    private static final int TOTAL_NUM_INSERTION_INDEX = 1;
+    private static final int TOTAL_NUM_DELETION_INDEX = 2;
+    private static final int FILE_STATS_COUNT = 3;
 
     private static final Pattern MESSAGEBODY_LEADING_PATTERN = Pattern.compile("^ {4}", Pattern.MULTILINE);
 
@@ -118,12 +125,38 @@ public class CommitInfoAnalyzer {
         }
 
         String[] statInfos = statLine.split(NEW_LINE_SPLITTER);
+
+        // Only copy from 0 to the second last element of statInfos (last line of statLine).
+        // Don't include the last element of statInfos in fileTypeContributions as it stores
+        // the total number of files changed, insertions and deletions.
         String[] fileTypeContributions = Arrays.copyOfRange(statInfos, 0, statInfos.length - 1);
         Map<FileType, ContributionPair> fileTypeAndContributionMap =
                 getFileTypesAndContribution(fileTypeContributions, config);
 
+        // Extract number of files changed, total insertions and deletions
+        String fileChangeSummaryString = statInfos[statInfos.length - 1];
+        FileChangeStats fileChangeStats = getFileChangeStats(fileChangeSummaryString);
+
         return new CommitResult(author, hash, isMergeCommit, adjustedDate, messageTitle, messageBody, tags,
-                fileTypeAndContributionMap);
+                fileTypeAndContributionMap, fileChangeStats);
+    }
+
+    private FileChangeStats getFileChangeStats(String fileChangeSummaryString) {
+        String[] patterns = {
+                "(\\d+)\\s+files? changed",         // "X file(s) changed"
+                "(\\d+)\\s+insertions?\\(\\+\\)",    // "Y insertions(+)"
+                "(\\d+)\\s+deletions?\\(-\\)"        // "Z deletions(-)"
+        };
+        int[] stats = new int[patterns.length]; // [filesChanged, insertions, deletions]
+
+        for (int i = 0; i < patterns.length; i++) {
+            Matcher matcher = Pattern.compile(patterns[i]).matcher(fileChangeSummaryString);
+            // Get the integer value from the first parenthesized group in each pattern
+            // If pattern is found, parse the captured number; otherwise keep 0
+            stats[i] = matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
+        }
+        return new FileChangeStats(stats[NUM_FILES_CHANGED_INDEX], stats[TOTAL_NUM_INSERTION_INDEX],
+                stats[TOTAL_NUM_DELETION_INDEX]);
     }
 
     /**

--- a/src/main/java/reposense/commits/CommitsReporter.java
+++ b/src/main/java/reposense/commits/CommitsReporter.java
@@ -18,10 +18,12 @@ public class CommitsReporter {
     /**
      * Generates and returns the commit contribution summary for each repo in {@code config}.
      */
-    public CommitContributionSummary generateCommitSummary(RepoConfiguration config) {
+    public CommitContributionSummary generateCommitSummary(RepoConfiguration config,
+            boolean shouldIncludeCommitFileStats) {
         List<CommitInfo> commitInfos = commitInfoExtractor.extractCommitInfos(config);
 
-        List<CommitResult> commitResults = commitInfoAnalyzer.analyzeCommits(commitInfos, config);
+        List<CommitResult> commitResults = commitInfoAnalyzer.analyzeCommits(commitInfos, config,
+                shouldIncludeCommitFileStats);
 
         return commitResultAggregator.aggregateCommitResults(config, commitResults);
     }

--- a/src/main/java/reposense/commits/model/CommitResult.java
+++ b/src/main/java/reposense/commits/model/CommitResult.java
@@ -28,14 +28,7 @@ public class CommitResult {
     public CommitResult(Author author, String hash, Boolean isMergeCommit, LocalDateTime time, String messageTitle,
                         String messageBody, String[] tags, Map<FileType, ContributionPair> fileTypesAndContributionMap,
                         FileChangeStats fileChangeStats) {
-        this.author = author;
-        this.hash = hash;
-        this.isMergeCommit = isMergeCommit;
-        this.time = time;
-        this.messageTitle = messageTitle;
-        this.messageBody = messageBody;
-        this.tags = tags;
-        this.fileTypesAndContributionMap = fileTypesAndContributionMap;
+        this(author, hash, isMergeCommit, time, messageTitle, messageBody, tags, fileTypesAndContributionMap);
         this.fileChangeStats = fileChangeStats;
     }
 
@@ -105,6 +98,10 @@ public class CommitResult {
 
     public Map<FileType, ContributionPair> getFileTypesAndContributionMap() {
         return fileTypesAndContributionMap;
+    }
+
+    public FileChangeStats getFileChangeStats() {
+        return fileChangeStats;
     }
 
     @Override

--- a/src/main/java/reposense/commits/model/CommitResult.java
+++ b/src/main/java/reposense/commits/model/CommitResult.java
@@ -1,8 +1,10 @@
 package reposense.commits.model;
 
+import java.io.File;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import reposense.model.Author;
@@ -18,9 +20,24 @@ public class CommitResult {
     private final String messageBody;
     private final String[] tags;
     private final Map<FileType, ContributionPair> fileTypesAndContributionMap;
+    private FileChangeStats fileChangeStats;
 
     private final transient Author author;
     private final transient LocalDateTime time;
+
+    public CommitResult(Author author, String hash, Boolean isMergeCommit, LocalDateTime time, String messageTitle,
+                        String messageBody, String[] tags, Map<FileType, ContributionPair> fileTypesAndContributionMap,
+                        FileChangeStats fileChangeStats) {
+        this.author = author;
+        this.hash = hash;
+        this.isMergeCommit = isMergeCommit;
+        this.time = time;
+        this.messageTitle = messageTitle;
+        this.messageBody = messageBody;
+        this.tags = tags;
+        this.fileTypesAndContributionMap = fileTypesAndContributionMap;
+        this.fileChangeStats = fileChangeStats;
+    }
 
     public CommitResult(Author author, String hash, Boolean isMergeCommit, LocalDateTime time, String messageTitle,
             String messageBody, String[] tags, Map<FileType, ContributionPair> fileTypesAndContributionMap) {

--- a/src/main/java/reposense/commits/model/FileChangeStats.java
+++ b/src/main/java/reposense/commits/model/FileChangeStats.java
@@ -24,8 +24,8 @@ public class FileChangeStats {
         }
 
         FileChangeStats otherFileChangeStats = (FileChangeStats) other;
-        return numFilesChanged == otherFileChangeStats.numFilesChanged &&
-                totalInsertions == otherFileChangeStats.totalInsertions &&
-                totalDeletions == otherFileChangeStats.totalDeletions;
+        return numFilesChanged == otherFileChangeStats.numFilesChanged
+                && totalInsertions == otherFileChangeStats.totalInsertions
+                && totalDeletions == otherFileChangeStats.totalDeletions;
     }
 }

--- a/src/main/java/reposense/commits/model/FileChangeStats.java
+++ b/src/main/java/reposense/commits/model/FileChangeStats.java
@@ -1,0 +1,31 @@
+package reposense.commits.model;
+
+import java.io.File;
+
+public class FileChangeStats {
+    private final int numFilesChanged;
+    private final int totalInsertions;
+    private final int totalDeletions;
+
+    public FileChangeStats(int numFilesChanged, int totalInsertions, int totalDeletions) {
+        this.numFilesChanged = numFilesChanged;
+        this.totalInsertions = totalInsertions;
+        this.totalDeletions = totalDeletions;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof ContributionPair)) {
+            return false;
+        }
+
+        FileChangeStats otherFileChangeStats = (FileChangeStats) other;
+        return numFilesChanged == otherFileChangeStats.numFilesChanged &&
+                totalInsertions == otherFileChangeStats.totalInsertions &&
+                totalDeletions == otherFileChangeStats.totalDeletions;
+    }
+}

--- a/src/main/java/reposense/model/AbstractBlurbMap.java
+++ b/src/main/java/reposense/model/AbstractBlurbMap.java
@@ -41,4 +41,8 @@ public abstract class AbstractBlurbMap implements BlurbMap {
     public int hashCode() {
         return blurbMap.hashCode();
     }
+
+    public String toString() {
+        return blurbMap.toString();
+    }
 }

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -41,6 +41,8 @@ public class CliArguments {
     private boolean isPortfolio;
     private boolean isFreshClonePerformed = ArgsParser.DEFAULT_SHOULD_FRESH_CLONE;
     private boolean isOnlyTextRefreshed;
+    private boolean isPrettyPrintingUsed; // Json pretty printing
+    private boolean shouldIncludeCommitFileStats;
 
     private List<String> locations;
     private boolean isViewModeOnly;
@@ -56,14 +58,6 @@ public class CliArguments {
     private RepoBlurbMap repoBlurbMap;
     private AuthorBlurbMap authorBlurbMap;
     private ChartBlurbMap chartBlurbMap;
-
-    // basics learning
-    private boolean isPrettyPrintingUsed;
-
-    // basics learning
-    public boolean isPrettyPrintingUsed() {
-        return isPrettyPrintingUsed;
-    }
 
     /**
      * Constructs a {@code CliArguments} object without any parameters.
@@ -132,6 +126,12 @@ public class CliArguments {
 
     public boolean isFreshClonePerformed() {
         return isFreshClonePerformed;
+    }
+    public boolean isPrettyPrintingUsed() {
+        return isPrettyPrintingUsed;
+    }
+    public boolean shouldIncludeCommitFileStats() {
+        return shouldIncludeCommitFileStats;
     }
 
     public List<String> getLocations() {
@@ -261,7 +261,9 @@ public class CliArguments {
                 && this.isAuthorshipAnalyzed == otherCliArguments.isAuthorshipAnalyzed
                 && Objects.equals(this.originalityThreshold, otherCliArguments.originalityThreshold)
                 && this.isPortfolio == otherCliArguments.isPortfolio
-                && this.isOnlyTextRefreshed == otherCliArguments.isOnlyTextRefreshed;
+                && this.isOnlyTextRefreshed == otherCliArguments.isOnlyTextRefreshed
+                && this.isPrettyPrintingUsed == otherCliArguments.isPrettyPrintingUsed
+                && this.shouldIncludeCommitFileStats == otherCliArguments.shouldIncludeCommitFileStats;
     }
 
     /**
@@ -278,6 +280,11 @@ public class CliArguments {
 
         public Builder isPrettyPrintingUsed(boolean isPrettyPrintingUsed) {
             this.cliArguments.isPrettyPrintingUsed = isPrettyPrintingUsed;
+            return this;
+        }
+
+        public Builder shouldIncludeCommitFileStats(boolean shouldIncludeCommitFileStats) {
+            this.cliArguments.shouldIncludeCommitFileStats = shouldIncludeCommitFileStats;
             return this;
         }
 

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -57,6 +57,14 @@ public class CliArguments {
     private AuthorBlurbMap authorBlurbMap;
     private ChartBlurbMap chartBlurbMap;
 
+    // basics learning
+    private boolean isPrettyPrintingUsed;
+
+    // basics learning
+    public boolean isPrettyPrintingUsed() {
+        return isPrettyPrintingUsed;
+    }
+
     /**
      * Constructs a {@code CliArguments} object without any parameters.
      */
@@ -264,6 +272,13 @@ public class CliArguments {
 
         public Builder() {
             this.cliArguments = new CliArguments();
+        }
+
+        // basics learning
+
+        public Builder isPrettyPrintingUsed(boolean isPrettyPrintingUsed) {
+            this.cliArguments.isPrettyPrintingUsed = isPrettyPrintingUsed;
+            return this;
         }
 
         /**

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -105,7 +105,8 @@ public class ArgsParser {
     private static final Path DEFAULT_ASSETS_PATH = Paths.get(System.getProperty("user.dir")
             + File.separator + "assets" + File.separator);
 
-    public static final String[] JSON_PRINT_MODE_FLAGS = new String[]{"--use-json-pretty-printing", "-j"}; // added for basics learning
+    public static final String[] JSON_PRINT_MODE_FLAGS = new String[] {"--use-json-pretty-printing", "-j"}; // added for basics learning
+    public static final String[] EXCLUDE_COMMIT_STATS_FLAGS = new String[] {"--exclude-commit-stats", "-e"};
 
     private static ArgumentParser getArgumentParser() {
         ArgumentParser parser = ArgumentParsers
@@ -132,6 +133,11 @@ public class ArgsParser {
                 .dest(JSON_PRINT_MODE_FLAGS[0])
                 .action(Arguments.storeTrue())
                 .help("A flag to use json pretty printing when generating the json files.");
+
+        parser.addArgument(EXCLUDE_COMMIT_STATS_FLAGS)
+                .dest(EXCLUDE_COMMIT_STATS_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to include commits file stats in the commit summary.");
 
         parser.version("RepoSense " + RepoSense.getVersion());
         parser.addArgument(VERSION_FLAGS)
@@ -326,6 +332,7 @@ public class ArgsParser {
         boolean shouldRefreshOnlyText = results.get(REFRESH_ONLY_TEXT_FLAG[0]);
 
         boolean isJsonPrettyPrintingUsed = results.get(JSON_PRINT_MODE_FLAGS[0]); // json pretty printing
+        boolean shouldIncludeCommitFileStats = !(boolean) results.get(EXCLUDE_COMMIT_STATS_FLAGS[0]);
 
         CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
                 .configFolderPath(configFolderPath)
@@ -346,7 +353,8 @@ public class ArgsParser {
                 .isPortfolio(isPortfolio)
                 .isFreshClonePerformed(shouldPerformFreshCloning)
                 .isOnlyTextRefreshed(shouldRefreshOnlyText)
-                .isPrettyPrintingUsed(isJsonPrettyPrintingUsed); // json pretty printing
+                .isPrettyPrintingUsed(isJsonPrettyPrintingUsed) // json pretty printing
+                .shouldIncludeCommitFileStats(shouldIncludeCommitFileStats);
 
         LogsManager.setLogFolderLocation(outputFolderPath);
 

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -122,16 +122,16 @@ public class ArgsParser {
                 .addMutuallyExclusiveGroup(MESSAGE_HEADER_MUTEX)
                 .required(false);
 
-        // LEARNING BASICS
-        parser.addArgument(JSON_PRINT_MODE_FLAGS)
-                .dest(JSON_PRINT_MODE_FLAGS[0])
-                .action(Arguments.storeTrue())
-                .help("A flag to use json pretty printing when generating the json files.");
-
         // Boolean flags
         parser.addArgument(HELP_FLAGS)
                 .help("Show help message.")
                 .action(new HelpArgumentAction());
+
+        // Json print mode
+        parser.addArgument(JSON_PRINT_MODE_FLAGS)
+                .dest(JSON_PRINT_MODE_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to use json pretty printing when generating the json files.");
 
         parser.version("RepoSense " + RepoSense.getVersion());
         parser.addArgument(VERSION_FLAGS)
@@ -325,8 +325,7 @@ public class ArgsParser {
         boolean shouldPerformFreshCloning = results.get(FRESH_CLONING_FLAG[0]);
         boolean shouldRefreshOnlyText = results.get(REFRESH_ONLY_TEXT_FLAG[0]);
 
-        // added for basics learning
-        boolean isJsonPrettyPrintingUsed = results.get(JSON_PRINT_MODE_FLAGS[0]);
+        boolean isJsonPrettyPrintingUsed = results.get(JSON_PRINT_MODE_FLAGS[0]); // json pretty printing
 
         CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
                 .configFolderPath(configFolderPath)
@@ -347,7 +346,7 @@ public class ArgsParser {
                 .isPortfolio(isPortfolio)
                 .isFreshClonePerformed(shouldPerformFreshCloning)
                 .isOnlyTextRefreshed(shouldRefreshOnlyText)
-                .isPrettyPrintingUsed(isJsonPrettyPrintingUsed); // basics learning
+                .isPrettyPrintingUsed(isJsonPrettyPrintingUsed); // json pretty printing
 
         LogsManager.setLogFolderLocation(outputFolderPath);
 

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -105,6 +105,8 @@ public class ArgsParser {
     private static final Path DEFAULT_ASSETS_PATH = Paths.get(System.getProperty("user.dir")
             + File.separator + "assets" + File.separator);
 
+    public static final String[] JSON_PRINT_MODE_FLAGS = new String[]{"--use-json-pretty-printing", "-j"}; // added for basics learning
+
     private static ArgumentParser getArgumentParser() {
         ArgumentParser parser = ArgumentParsers
                 .newFor(PROGRAM_USAGE)
@@ -119,6 +121,12 @@ public class ArgsParser {
         MutuallyExclusiveGroup mutexParser2 = parser
                 .addMutuallyExclusiveGroup(MESSAGE_HEADER_MUTEX)
                 .required(false);
+
+        // LEARNING BASICS
+        parser.addArgument(JSON_PRINT_MODE_FLAGS)
+                .dest(JSON_PRINT_MODE_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to use json pretty printing when generating the json files.");
 
         // Boolean flags
         parser.addArgument(HELP_FLAGS)
@@ -317,6 +325,9 @@ public class ArgsParser {
         boolean shouldPerformFreshCloning = results.get(FRESH_CLONING_FLAG[0]);
         boolean shouldRefreshOnlyText = results.get(REFRESH_ONLY_TEXT_FLAG[0]);
 
+        // added for basics learning
+        boolean isJsonPrettyPrintingUsed = results.get(JSON_PRINT_MODE_FLAGS[0]);
+
         CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
                 .configFolderPath(configFolderPath)
                 .reportDirectoryPath(reportFolderPath)
@@ -335,7 +346,8 @@ public class ArgsParser {
                 .originalityThreshold(originalityThreshold)
                 .isPortfolio(isPortfolio)
                 .isFreshClonePerformed(shouldPerformFreshCloning)
-                .isOnlyTextRefreshed(shouldRefreshOnlyText);
+                .isOnlyTextRefreshed(shouldRefreshOnlyText)
+                .isPrettyPrintingUsed(isJsonPrettyPrintingUsed); // basics learning
 
         LogsManager.setLogFolderLocation(outputFolderPath);
 

--- a/src/main/java/reposense/report/RepoCloner.java
+++ b/src/main/java/reposense/report/RepoCloner.java
@@ -190,6 +190,7 @@ public class RepoCloner {
             crp = GitClone.cloneBareAsync(config, Paths.get("."), outputDirectory.toString());
         } catch (GitCloneException | IOException e) {
             logger.log(Level.WARNING, String.format(MESSAGE_ERROR_CLONING, config.getDisplayName()), e);
+            ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), e.getMessage()); // add error during git clone into error summary
             return false;
         }
         return true;
@@ -325,6 +326,7 @@ public class RepoCloner {
         } catch (RuntimeException | CommandRunnerProcessException e) {
             crp = null;
             logger.log(Level.WARNING, String.format(MESSAGE_ERROR_CLONING, config.getDisplayName()), e);
+            ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), e.getMessage()); // add error message into error summary
             return false;
         }
         crp = null;

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -108,19 +108,12 @@ public class FileUtil {
      * was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
-        /*
-        Gson gson = new GsonBuilder()
-                .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
-                .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
-                .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer())
-                .create();*/
-
-        // basics learning
         GsonBuilder gsonBuilder = new GsonBuilder()
                 .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
                 .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer());
         Gson gson;
+        // Json pretty printing
         if (isPrettyPrintingUsed) {
             gson = gsonBuilder.setPrettyPrinting().create();
         } else {

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -43,6 +43,7 @@ import reposense.util.adapters.ZoneSerializer;
  * Contains file processing related functionalities.
  */
 public class FileUtil {
+    private static boolean isPrettyPrintingUsed = false; // basics learning
     public static final String REPOS_ADDRESS = "repos";
 
     // zip file which contains all the specified file types
@@ -107,11 +108,24 @@ public class FileUtil {
      * was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
+        /*
         Gson gson = new GsonBuilder()
                 .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
                 .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer())
-                .create();
+                .create();*/
+
+        // basics learning
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
+                .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
+                .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer());
+        Gson gson;
+        if (isPrettyPrintingUsed) {
+            gson = gsonBuilder.setPrettyPrinting().create();
+        } else {
+            gson = gsonBuilder.create();
+        }
 
         // Gson serializer from:
         // https://stackoverflow.com/questions/39192945/serialize-java-8-localdate-as-yyyy-mm-dd-with-gson
@@ -126,6 +140,11 @@ public class FileUtil {
             logger.log(Level.SEVERE, e.getMessage(), e);
             return Optional.empty();
         }
+    }
+
+    //basics learning
+    public static void setPrettyPrintingMode(boolean isPrettyPrintingAdopted) {
+        isPrettyPrintingUsed = isPrettyPrintingAdopted;
     }
 
     /**

--- a/src/test/java/reposense/report/ReportGeneratorTest.java
+++ b/src/test/java/reposense/report/ReportGeneratorTest.java
@@ -59,7 +59,7 @@ class ReportGeneratorTest {
                 LocalDateTime.parse("2025-03-16T23:59:59", DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT)),
                 false, false, 4, 12, TimeUtil::getElapsedTime,
                 ZoneId.of("Asia/Singapore"), false, false, 0.51,
-                repoBlurbMap, authorBlurbMap, chartBlurbMap, false, true);
+                repoBlurbMap, authorBlurbMap, chartBlurbMap, false, true, false);
 
         SummaryJson actualSummaryJson = new SummaryJsonParser().parse(SUMMARY_JSON_PATH);
 
@@ -84,7 +84,7 @@ class ReportGeneratorTest {
                         LocalDateTime.parse("2025-03-16T23:59:59", DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT)),
                         false, false, 4, 12, TimeUtil::getElapsedTime,
                         ZoneId.of("Asia/Singapore"), false, false, 0.51,
-                        repoBlurbMap, authorBlurbMap, chartBlurbMap, false, true)
+                        repoBlurbMap, authorBlurbMap, chartBlurbMap, false, true, false)
         );
     }
 


### PR DESCRIPTION
## Add new fields
Add `FileChangeStats` class to store file change metrics (files changed, insertions, deletions) in `CommitResult`, which are then stored in commits.json.

Key changes:
Parse the last element of `statsInfo` in `CommitInfoAnalyzer` (line 127).
As its string is always in the form of "x file(s) changed, y insertion(s)(+), z deletion(s)(-)", I use `Pattern` to fetch the integer values from the string.

![image](https://github.com/user-attachments/assets/98eb52e4-88b0-4a12-9c44-dcab14e7972d)

## Add new flag
Add `--exclude-commit-stats` or `-e` to exclude the `fileTypesAndContributionMap` and `fileChangeStats` in the generated commits.json file. This allows user to generate a light weight commit summary.

Changes:
Add new flag to `ArgsParser` class then get the boolean value in `CliArguments`. Create different `CommitResult` objects based on the flag condition/boolean value.

![image](https://github.com/user-attachments/assets/22e12c96-5b03-462a-8813-09a3a7ca0dff)






